### PR TITLE
fix build/testing without prior selenium driver download and setup. This w…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.vaadin</groupId>
     <artifactId>testbench-demo</artifactId>
@@ -57,8 +57,8 @@
             </plugin>
 
             <!-- A simple Jetty test server at http://localhost:8080/
-            can be launched with the Maven goal jetty:run and stopped with jetty:stop.
-            Also configured to run during the integration-test phase -->
+                can be launched with the Maven goal jetty:run and stopped with jetty:stop.
+                Also configured to run during the integration-test phase -->
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
@@ -97,7 +97,7 @@
             </plugin>
 
             <!-- The Surefire plugin will run our *ITCase tests in the integration-test
-            phase and do the reporting in the verify phase -->
+                phase and do the reporting in the verify phase -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.vaadin</groupId>
     <artifactId>testbench-demo</artifactId>
@@ -57,8 +57,8 @@
             </plugin>
 
             <!-- A simple Jetty test server at http://localhost:8080/
-                can be launched with the Maven goal jetty:run and stopped with jetty:stop. 
-                Also configured to run during the integration-test phase -->
+            can be launched with the Maven goal jetty:run and stopped with jetty:stop.
+            Also configured to run during the integration-test phase -->
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
@@ -69,7 +69,7 @@
                 </configuration>
                 <executions>
                     <!-- start and stop jetty (running our app) when running
-                        integration tests -->
+                    integration tests -->
                     <execution>
                         <id>start-jetty</id>
                         <phase>pre-integration-test</phase>
@@ -96,8 +96,8 @@
                 </executions>
             </plugin>
 
-            <!-- The Surefire plugin will run our *ITCase tests in the integration-test 
-                phase and do the reporting in the verify phase -->
+            <!-- The Surefire plugin will run our *ITCase tests in the integration-test
+            phase and do the reporting in the verify phase -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -115,15 +115,41 @@
                         <include>**/*ITCase.java</include>
                         <include>**/bdd/*.java</include>
                     </includes>
-                    <!-- So that the browser correctly gains focus on Mac 
-                        OS X -->
+                    <!-- So that the browser correctly gains focus on Mac
+                    OS X -->
                     <systemProperties>
                         <property>
                             <name>java.awt.headless</name>
                             <value>true</value>
                         </property>
                     </systemProperties>
+                    <trimStackTrace>false</trimStackTrace>
+                    <systemPropertyVariables>
+                        <!-- Pass location of downloaded webdrivers to the tests -->
+                        <webdriver.chrome.driver>${webdriver.chrome.driver}</webdriver.chrome.driver>
+                    </systemPropertyVariables>
                 </configuration>
+            </plugin>
+            <!-- Plugin which automatically downloads needed webdrivers -->
+            <!-- Configured in webdriver.xml. -->
+            <!-- Currently only downloads Chromedriver, remove commented
+            out parts of webdriver.xml to download other webdrivers -->
+            <plugin>
+                <groupId>com.lazerycode.selenium</groupId>
+                <artifactId>driver-binary-downloader-maven-plugin</artifactId>
+                <version>1.0.17</version>
+                <configuration>
+                    <downloadedZipFileDirectory>${project.basedir}/webdriver/zips</downloadedZipFileDirectory>
+                    <rootStandaloneServerDirectory>${project.basedir}/webdriver</rootStandaloneServerDirectory>
+                    <customRepositoryMap>${project.basedir}/webdrivers.xml</customRepositoryMap>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>selenium</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -156,12 +182,12 @@
             <version>${vaadin.testbench.version}</version>
             <scope>test</scope>
         </dependency>
-	<dependency>
-	    <groupId>com.vaadin</groupId>
-	    <artifactId>vaadin-testbench-api</artifactId>
-	    <version>${vaadin.version}</version>
-	    <scope>test</scope>
-	</dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-testbench-api</artifactId>
+            <version>${vaadin.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/webdrivers.xml
+++ b/webdrivers.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<root>
+    <windows>
+        <!--
+        <driver id="internetexplorer">
+            <version id="3.7.0">
+                <bitrate sixtyfourbit="true">
+                    <filelocation>http://selenium-release.storage.googleapis.com/3.7/IEDriverServer_x64_3.7.0.zip</filelocation>
+                    <hash>f6a0d7939355acba00f7b1374bebda50bbead59b</hash>
+                    <hashtype>sha1</hashtype>
+                </bitrate>
+                <bitrate thirtytwobit="true">
+                    <filelocation>http://selenium-release.storage.googleapis.com/3.7/IEDriverServer_Win32_3.7.0.zip</filelocation>
+                    <hash>ded0a82cab46538751ba17206f55c112674585d6</hash>
+                    <hashtype>sha1</hashtype>
+                </bitrate>
+            </version>
+        </driver>
+        <driver id="edge">
+            <version id="5.16299">
+                <bitrate sixtyfourbit="true" thirtytwobit="true">
+                    <filelocation>https://download.microsoft.com/download/D/4/1/D417998A-58EE-4EFE-A7CC-39EF9E020768/MicrosoftWebDriver.exe</filelocation>
+                    <hash>60c4b6d859ee868ba5aa29c1e5bfa892358e3f96</hash>
+                    <hashtype>sha1</hashtype>
+                </bitrate>
+            </version>
+        </driver>
+        -->
+        <driver id="googlechrome">
+            <version id="2.38">
+                <bitrate thirtytwobit="true" sixtyfourbit="true">
+                    <filelocation>http://chromedriver.storage.googleapis.com/2.38/chromedriver_win32.zip</filelocation>
+                    <hash>913f2233ad1de3ef32c597d10688ef2fef2333d5</hash>
+                    <hashtype>sha1</hashtype>
+                </bitrate>
+            </version>
+        </driver>
+        <!--
+        <driver id="operachromium">
+            <version id="2.30">
+                <bitrate sixtyfourbit="true">
+                    <filelocation>https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_win64.zip</filelocation>
+                    <hash>bf80617b01708ced97f7cc174e72a1b6953ae126</hash>
+                    <hashtype>sha1</hashtype>
+                </bitrate>
+                <bitrate thirtytwobit="true">
+                    <filelocation>https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_win32.zip</filelocation>
+                    <hash>151dc7ae316be2ccc52c28395823c778ccfda5ac</hash>
+                    <hashtype>sha1</hashtype>
+                </bitrate>
+            </version>
+        </driver>
+        <driver id="phantomjs">
+            <version id="2.1.1">
+                <bitrate thirtytwobit="true" sixtyfourbit="true">
+                    <filelocation>https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-windows.zip</filelocation>
+                    <hash>eb61e6dc49832a3d60f708a92fa7299c57cad7db</hash>
+                    <hashtype>sha1</hashtype>
+                </bitrate>
+            </version>
+        </driver>
+        <driver id="marionette">
+            <version id="0.19.1">
+                <bitrate sixtyfourbit="true">
+                    <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-win64.zip</filelocation>
+                    <hash>1d6a7ade773f98b3b5a15ace3b6a06b1ad97a8f1</hash>
+                    <hashtype>sha1</hashtype>
+                </bitrate>
+                <bitrate thirtytwobit="true">
+                    <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-win32.zip</filelocation>
+                    <hash>74258f5c73a8fce66fbc3ecd622dae890f1e475a</hash>
+                    <hashtype>sha1</hashtype>
+                </bitrate>
+            </version>
+        </driver>
+        -->
+    </windows>
+    <linux>
+        <driver id="googlechrome">
+            <version id="2.38">
+                <bitrate sixtyfourbit="true">
+                    <filelocation>https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip</filelocation>
+                    <hash>37741d14df5ed6bc3fcdf025b2d2ae1a0fc73216</hash>
+                    <hashtype>sha1</hashtype>
+                </bitrate>
+            </version>
+        </driver>
+        <!--
+       <driver id="operachromium">
+           <version id="2.30">
+               <bitrate sixtyfourbit="true">
+                   <filelocation>https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_linux64.zip</filelocation>
+                   <hash>a8528276dab36e5daa6213db16ac4ae227e8394d</hash>
+                   <hashtype>sha1</hashtype>
+               </bitrate>
+           </version>
+       </driver>
+       <driver id="phantomjs">
+           <version id="2.1.1">
+               <bitrate sixtyfourbit="true">
+                   <filelocation>https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2</filelocation>
+                   <hash>f8afc8a24eec34c2badccc93812879a3d6f2caf3</hash>
+                   <hashtype>sha1</hashtype>
+               </bitrate>
+               <bitrate thirtytwobit="true">
+                   <filelocation>https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-i686.tar.bz2</filelocation>
+                   <hash>9870663f5c2826501508972b8a201d9210d27b59</hash>
+                   <hashtype>sha1</hashtype>
+               </bitrate>
+           </version>
+       </driver>
+       <driver id="marionette">
+           <version id="0.19.1">
+               <bitrate sixtyfourbit="true">
+                   <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz</filelocation>
+                   <hash>9284c82e1a6814ea2a63841cd532d69b87eb0d6e</hash>
+                   <hashtype>sha1</hashtype>
+               </bitrate>
+               <bitrate thirtytwobit="true">
+                   <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux32.tar.gz</filelocation>
+                   <hash>9375768a70365d361029f050d73e03aba0ece351</hash>
+                   <hashtype>sha1</hashtype>
+               </bitrate>
+               <bitrate arm="true">
+                   <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-arm7hf.tar.gz</filelocation>
+                   <hash>115ad6e36c03445fed1499112156472eaa5faa1d</hash>
+                   <hashtype>sha1</hashtype>
+               </bitrate>
+           </version>
+       </driver>
+        -->
+    </linux>
+    <osx>
+        <driver id="googlechrome">
+            <version id="2.38">
+                <bitrate sixtyfourbit="true">
+                    <filelocation>https://chromedriver.storage.googleapis.com/2.38/chromedriver_mac64.zip</filelocation>
+                    <hash>54b11f9c3d64e84a9f4da3592154bfb0dedb59af</hash>
+                    <hashtype>sha1</hashtype>
+                </bitrate>
+            </version>
+        </driver>
+        <!--
+        <driver id="operachromium">
+            <version id="2.30">
+                <bitrate sixtyfourbit="true">
+                    <filelocation>https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.30/operadriver_mac64.zip</filelocation>
+                    <hash>2b5273762c7f7c3d8ad61c03f7cbf4d0825b918b</hash>
+                    <hashtype>sha1</hashtype>
+                </bitrate>
+            </version>
+        </driver>
+        <driver id="phantomjs">
+            <version id="2.1.1">
+                <bitrate thirtytwobit="true" sixtyfourbit="true">
+                    <filelocation>https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip</filelocation>
+                    <hash>c6e1a16bb9e89ce1e392a4768e99177797c93350</hash>
+                    <hashtype>sha1</hashtype>
+                </bitrate>
+            </version>
+        </driver>
+        <driver id="marionette">
+            <version id="0.19.1">
+                <bitrate thirtytwobit="true" sixtyfourbit="true">
+                    <filelocation>https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-macos.tar.gz</filelocation>
+                    <hash>ae350f4510bbc0a8526f3fbfced8065b1b8586b2</hash>
+                    <hashtype>sha1</hashtype>
+                </bitrate>
+            </version>
+        </driver>
+        -->
+    </osx>
+</root>


### PR DESCRIPTION
…as copied from the master branch

Currently this branch does not compile with tests on unless you download Chrome selenium driver and setup environment to properly locate the driver. These changes use the same technique the master branch uses to automatically download and setup the failsafe plugin so selenium runs properly out of the box.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/testbench-demo/14)
<!-- Reviewable:end -->
