### PR TITLE
Revert "Fix IDEs error with Java 16"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,32 +132,27 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <!-- Plugin which automatically downloads needed webdrivers -->
+            <!-- Configured in webdriver.xml. -->
+            <!-- Currently only downloads Chromedriver, remove commented 
+                out parts of webdriver.xml to download other webdrivers -->
+            <plugin>
+                <groupId>com.lazerycode.selenium</groupId>
+                <artifactId>driver-binary-downloader-maven-plugin</artifactId>
+                <version>1.0.17</version>
+                <configuration>
+                    <downloadedZipFileDirectory>${project.basedir}/webdriver/zips</downloadedZipFileDirectory>
+                    <rootStandaloneServerDirectory>${project.basedir}/webdriver</rootStandaloneServerDirectory>
+                    <customRepositoryMap>${project.basedir}/webdrivers.xml</customRepositoryMap>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>selenium</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
-
-        <pluginManagement>
-            <plugins>
-                <!-- Plugin which automatically downloads needed webdrivers -->
-                <!-- Configured in webdriver.xml. -->
-                <!-- Currently only downloads Chromedriver, remove commented
-                    out parts of webdriver.xml to download other webdrivers -->
-                <plugin>
-                    <groupId>com.lazerycode.selenium</groupId>
-                    <artifactId>driver-binary-downloader-maven-plugin</artifactId>
-                    <version>1.0.17</version>
-                    <configuration>
-                        <downloadedZipFileDirectory>${project.basedir}/webdriver/zips</downloadedZipFileDirectory>
-                        <rootStandaloneServerDirectory>${project.basedir}/webdriver</rootStandaloneServerDirectory>
-                        <customRepositoryMap>${project.basedir}/webdrivers.xml</customRepositoryMap>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>selenium</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
 </project>


### PR DESCRIPTION
Reverts vaadin/testbench-demo#31

The fix makes `mvn verify` not work as it never downloads the webdriver