### PR TITLE
chore: Update to latest versions for V8

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ dependencies were added:
 	<dependency>
 		<groupId>com.vaadin</groupId>
 		<artifactId>vaadin-testbench</artifactId>
-		<version>4.1.0</version>
+		<version>5.2.0</version>
 		<scope>test</scope>
 	</dependency>
 	<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,18 +11,18 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <vaadin.version>8.0.0</vaadin.version>
+        <vaadin.version>8.14.3</vaadin.version>
         <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
-        <vaadin.testbench.version>5.0.0</vaadin.testbench.version>
+        <vaadin.testbench.version>5.2.0</vaadin.testbench.version>
     </properties>
     <repositories>
         <repository>
             <id>vaadin-addons</id>
-            <url>http://maven.vaadin.com/vaadin-addons</url>
+            <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
         <repository>
             <id>vaadin-snapshots</id>
-            <url>http://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
+            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -34,7 +34,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>vaadin-snapshots</id>
-            <url>http://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
+            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>

--- a/webdrivers.xml
+++ b/webdrivers.xml
@@ -27,10 +27,10 @@
         </driver>
         -->
         <driver id="googlechrome">
-            <version id="2.38">
+            <version id="100.0.4896.60">
                 <bitrate thirtytwobit="true" sixtyfourbit="true">
-                    <filelocation>http://chromedriver.storage.googleapis.com/2.38/chromedriver_win32.zip</filelocation>
-                    <hash>913f2233ad1de3ef32c597d10688ef2fef2333d5</hash>
+                    <filelocation>http://chromedriver.storage.googleapis.com/100.0.4896.60/chromedriver_win32.zip</filelocation>
+                    <hash>f3db8014494e0fd32ac78d4f1c814c9755198e3b</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
@@ -77,10 +77,10 @@
     </windows>
     <linux>
         <driver id="googlechrome">
-            <version id="2.38">
+            <version id="100.0.4896.60">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip</filelocation>
-                    <hash>37741d14df5ed6bc3fcdf025b2d2ae1a0fc73216</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/100.0.4896.60/chromedriver_linux64.zip</filelocation>
+                    <hash>5ffae20015cdc2cb19dc41a6588d6564be1ec9a1</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
@@ -132,10 +132,10 @@
     </linux>
     <osx>
         <driver id="googlechrome">
-            <version id="2.38">
+            <version id="100.0.4896.60">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/2.38/chromedriver_mac64.zip</filelocation>
-                    <hash>54b11f9c3d64e84a9f4da3592154bfb0dedb59af</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/100.0.4896.60/chromedriver_mac64.zip</filelocation>
+                    <hash>bb2e7e079e4d33a2a468ebc0a3d43ba8b5eea240</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>


### PR DESCRIPTION
Vaadin version updated to 8.14.3
Testbench version updated to 5.2.0
Chromedriver updated to 100.0.4896.60 Chrome 100
